### PR TITLE
Early exit for browsers without Element/HTMLElement support (IE<8).

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -1,4 +1,3 @@
-
 /*
  * classList.js: Cross-browser full element.classList implementation.
  * 2011-06-15
@@ -17,6 +16,8 @@ if (typeof document !== "undefined" && !("classList" in document.createElement("
 (function (view) {
 
 "use strict";
+
+if (!('HTMLElement' in view) && !('Element' in view)) return;
 
 var
 	  classListProp = "classList"


### PR DESCRIPTION
IE7 barks because of lack of Element/HTMLElement object. Not sure how you build minified source so altered the source file only.

Thanks a lot for this script!
Jakub Pawlowicz
