### PR TITLE
Toggle function returns incorrect value

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -147,7 +147,7 @@ classListProto.toggle = function (token, forse) {
 		this[method](token);
 	}
 
-	return result;
+	return !result;
 };
 classListProto.toString = function () {
 	return this.join(" ");


### PR DESCRIPTION
On Chrome, `elem.classList.toggle('someClass')` returns true if the class was added. Whereas this shim seems to return true if the class was removed.
