### PR TITLE
Modified classList.js to svgclasslist.js

### DIFF
--- a/svgclasslist.js
+++ b/svgclasslist.js
@@ -16,8 +16,7 @@
 /*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
 
 if (typeof document !== "undefined" &&
-	document.getElementsByTagName("svg").length > 0 &&
-	!("classList" in document.getElementsByTagName("svg")[0])) {
+	!("classList" in document.createElementNS("http://www.w3.org/2000/svg", "svg"))) {
 
 (function (view) {
 


### PR DESCRIPTION
(older) WebKit browsers have support for inline SVG and for classList, but don't have support for classList on inline SVG elements.

What's more, .className on <svg> element returns "[object SVGAnimatedString]".

~~Even worse, this issue only seems to affect SVG elements already in the document. Creating a new one (using document.createElement('svg')) seems to have classList.~~

This issue affects Safari (tested version 5.1 on Windows) and Android browser. Probably affects other WebKit browsers too.

This issue does not affect Chrome, Opera or Firefox. These browsers work correctly.

Even if you don't accept this pull request (that's fine for me), I just wanted to raise awareness about this little-known issue. The modified svgclasslist.js script solves this issue for me.
