### PR TITLE
Fixes detection of classList in SVG elements.

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -11,7 +11,10 @@
 
 /*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
 
-if ("document" in self && !("classList" in document.createElement("_"))) {
+if ("document" in self && !(
+		"classList" in document.createElement("_") &&
+		"classList" in document.createElementNS("http://www.w3.org/2000/svg", "svg")
+	)) {
 
 (function (view) {
 


### PR DESCRIPTION
Tested in Safari 5.1.7 on Windows and in Android Browser (WebKit-based).
