### PR TITLE
Fix toggle return value to match spec

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -149,7 +149,11 @@ classListProto.toggle = function (token, force) {
 		this[method](token);
 	}
 
-	return !result;
+	if (force === true || force === false) {
+		return force;
+	} else {
+		return !result;
+	}
 };
 classListProto.toString = function () {
 	return this.join(" ");


### PR DESCRIPTION
This change makes the return value of `toggle` match the current `DOMTokenList` spec in cases where toggle is passed a `force` argument but the resulting classList doesn't change. (The class toggling behavior is correct as is; this just fixes the return value.) For example, it fixes this case:

``` js
document.createElement('b').classList.toggle('a', false);
// Spec says return `false` because token 'a' was not added
// classList.js returns `true`
```

Reference: [DOMTokenList spec](http://dom.spec.whatwg.org/#domtokenlist), where `.toggle(token[, force])` behavior is: 

> If force is not given, "toggles" token, removing it if it's present and adding it if it's not. If force is true, adds token (same as add()). If force is false, removes token (same as remove()).
> 
> Returns true if token is now present, and false otherwise.
