### PR TITLE
Normalize add, remove, and toggle to support multiple arguments

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -180,7 +180,7 @@ if (objCtr.defineProperty) {
 
 } else {
 // There is full or partial native classList support, so just check if we need
-// to normalize the add/remove API.
+// to normalize the add/remove and toggle APIs.
 
 (function () {
 	"use strict";
@@ -206,6 +206,23 @@ if (objCtr.defineProperty) {
 		};
 		createMethod('add');
 		createMethod('remove');
+	}
+
+	testElement.classList.toggle("c3", false);
+
+	// Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+	// support the second argument.
+	if (testElement.classList.contains("c3")) {
+		var _toggle = DOMTokenList.prototype.toggle;
+
+		DOMTokenList.prototype.toggle = function(token, force) {
+			if (1 in arguments && !this.contains(token) === !force) {
+				return force;
+			} else {
+				return _toggle.call(this, token);
+			}
+		};
+
 	}
 
 	testElement = null;


### PR DESCRIPTION
This change would normalize `add`, `remove`, and `toggle` to always support multiple arguments in browsers with older classList implementations. 

Currently, in browsers with older classList implementations like IE10/11 and Firefox <26, calling something like `myElement.classList.add("class1", "class2")` would only add the first token `"class1"` to the list. This shims `add`, `remove`, and `toggle` to match the current [spec](http://dom.spec.whatwg.org/#domtokenlist) behavior when called with multiple arguments. Updated behavior:
- `add(tokens…)` can add multiple tokens at once
- `remove(tokens…)` can remove multiple tokens at once
- `toggle(token[, force])` accepts an optional boolean argument that dictates whether to add/remove the token

If the browser supports multiple arguments already, this shouldn't override the native implementation. 

This is similar to https://github.com/eligrey/classList.js/pull/6 in goal, just with a smaller diff. (H/T to @mislav for inspiration on the add/remove and toggle implementations.)
