### PR TITLE
Instructions for updating public CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@ classList.js is a cross-browser JavaScript shim that fully implements `element.c
 
 This works in every browser except IE 7 or earlier.
 
-The current version is hosted at public CDNs, allowing you to use this already small file at nearly zero size overhead. Use one of these URLs:
+An older version is hosted at public CDNs, allowing you to use this already small file at nearly zero size overhead. Use one of these URLs:
 
-  - [//cdnjs.cloudflare.com/ajax/libs/classlist/2014.07.23/classList.min.js](//cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js)
-  - [//cdn.jsdelivr.net/classlist/2014.07.23/classList.min.js](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js)
+  - [//cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js](//cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js)
+  - [//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js)
+
+If you would like other versions (such as the current one) hosted there, follow the instructions at 
+https://github.com/jsdelivr/jsdelivr
+and
+https://github.com/cdnjs/cdnjs
+to prepare a pull request.
 
 ![Tracking image](https://in.getclicky.com/212712ns.gif)
 


### PR DESCRIPTION
Reverted CDN links to the actually existing (rather than the desired) URL and added instructions for updating the files served by the CDNs.
