### PR TITLE
add Support for missing SVGElement.classList in IE

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -16,7 +16,7 @@ if ("document" in self) {
 // Full polyfill for browsers with no classList support
 // Including IE < Edge missing SVGElement.classList
 if (!("classList" in document.createElement("_")) 
-	|| document.createElementNS && !("classlist" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
+	|| document.createElementNS && !("classList" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
 
 (function (view) {
 

--- a/classList.js
+++ b/classList.js
@@ -14,7 +14,9 @@
 if ("document" in self) {
 
 // Full polyfill for browsers with no classList support
-if (!("classList" in document.createElement("_"))) {
+// Including IE < Edge missing SVGElement.classList
+if (!("classList" in document.createElement("_")) 
+	|| document.createElementNS && !("classlist" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
 
 (function (view) {
 


### PR DESCRIPTION
does the bare minimum to support IE's missing classList on SVG elements. Does a secondary check to see if it's missing on SVG elements, and lets the standard full patch be added to Element, so that SVGElement can inherit it.