### PR TITLE
Update package.json's license to be The Unlicense

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cross-browser"
   ],
   "author": "me@eligrey.com",
-  "license": "Public Domain",
+  "license": "Unlicense",
   "bugs": {
     "url": "https://github.com/eligrey/classList.js/issues"
   },


### PR DESCRIPTION
Resolves npm warning:
> license should be a valid SPDX license expression