### PR TITLE
Always check & upgrade partial implementations.

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -184,7 +184,8 @@ if (objCtr.defineProperty) {
 
 }(self));
 
-} else {
+}
+
 // There is full or partial native classList support, so just check if we need
 // to normalize the add/remove and toggle APIs.
 
@@ -235,6 +236,3 @@ if (objCtr.defineProperty) {
 }());
 
 }
-
-}
-


### PR DESCRIPTION
Tests are failing in IE, the partial implementation of `toggle` is not
being upgraded.

The branching logic is broken, IE no longer falls into the `else` block
since SVG checks were added.

Since the `else` does not provide much value, removing is a simple fix.

ping @eligrey 

fixes: https://github.com/eligrey/classList.js/issues/54 https://github.com/eligrey/classList.js/issues/44
