### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This works in every browser except IE 7 or earlier.
 An older version is hosted at public CDNs, allowing you to use this already small file at nearly zero size overhead. Use one of these URLs:
 
   - [//cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js](//cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js)
-  - [//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js)
+  - [//cdn.jsdelivr.net/npm/classlist.js@1.1.20150312/classList.min.js](//cdn.jsdelivr.net/classlist/2014.01.31/classList.min.js)
 
 If you would like other versions (such as the current one) hosted there, follow the instructions at 
 https://github.com/jsdelivr/jsdelivr


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/classlist.js.

Feel free to ping me if you have any questions regarding this change.