### PR TITLE
Fix logic for classList methods

### DIFF
--- a/classList.js
+++ b/classList.js
@@ -94,7 +94,7 @@ classListProto.item = function (i) {
 	return this[i] || null;
 };
 classListProto.contains = function (token) {
-	return !~checkTokenAndGetIndex(this, token + "");
+	return checkTokenAndGetIndex(this, token + "") !== -1;
 };
 classListProto.add = function () {
 	var
@@ -106,7 +106,7 @@ classListProto.add = function () {
 	;
 	do {
 		token = tokens[i] + "";
-		if (~checkTokenAndGetIndex(this, token)) {
+		if (checkTokenAndGetIndex(this, token) === -1) {
 			this.push(token);
 			updated = true;
 		}
@@ -129,7 +129,7 @@ classListProto.remove = function () {
 	do {
 		token = tokens[i] + "";
 		index = checkTokenAndGetIndex(this, token);
-		while (~index) {
+		while (index !== -1) {
 			this.splice(index, 1);
 			updated = true;
 			index = checkTokenAndGetIndex(this, token);
@@ -162,7 +162,7 @@ classListProto.toggle = function (token, force) {
 };
 classListProto.replace = function (token, replacement_token) {
 	var index = checkTokenAndGetIndex(token + "");
-	if (~index) {
+	if (index !== -1) {
 		this.splice(index, 1, replacement_token);
 		this._updateClassName();
 	}
@@ -248,7 +248,7 @@ if (objCtr.defineProperty) {
 				  tokens = this.toString().split(" ")
 				, index = tokens.indexOf(token + "")
 			;
-			if (~index) {
+			if (index !== -1) {
 				tokens = tokens.slice(index);
 				this.remove.apply(this, tokens);
 				this.add(replacement_token);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -55,6 +55,23 @@ QUnit.test("Adds class with second argument", function(assert) {
 	);
 });
 
+
+QUnit.test("Adds class to an svg", function(assert) {
+	var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+	var cList = svg.classList;
+
+	cList.add("c1");
+	assert.ok(svg.getAttribute("class") === "c1", "Adds a class");
+});
+
+QUnit.test("Toggle class to an svg", function(assert) {
+	var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+	var cList = svg.classList;
+
+	cList.toggle("c1");
+	assert.ok(svg.getAttribute("class") === "c1", "Togle a class (not present)");
+});
+
 QUnit.test("Removes class with second argument", function(assert) {
 	var cList = document.createElement("p").classList;
 


### PR DESCRIPTION
The change commit 1e80f5082a2b2c497a3b3f6ff692c1e98cfdbe1b broke the logic on the classList methods. 

The tests are incomplete and only testing the DOMTokenList override, but not the whole classList prototype on Element.

Reverted the logic and added tests.

